### PR TITLE
F/103 posterior allele frequency

### DIFF
--- a/cli-assemble-help.txt
+++ b/cli-assemble-help.txt
@@ -113,7 +113,7 @@ optional arguments:
   --report [REPORT ...]
                         Extra fields to report within the output VCF: GP =
                         genotype posterior probabilities; GL = genotype
-                        likelihoods.
+                        likelihoods; AFP = posterior mean allele frequencies.
   --cores CORES         Number of cpu cores to use (default = 1).
   --mcmc-chains MCMC_CHAINS
                         Number of independent MCMC chains per assembly

--- a/cli-assemble-help.txt
+++ b/cli-assemble-help.txt
@@ -1,19 +1,18 @@
 usage: MCMC haplotype assembly [-h] [--region REGION] [--region-id REGION_ID]
                                [--targets TARGETS] [--variants VARIANTS]
-                               [--reference REFERENCE] [--bam [BAM [BAM ...]]]
+                               [--reference REFERENCE] [--bam [BAM ...]]
                                [--bam-list BAM_LIST] [--sample-bam SAMPLE_BAM]
-                               [--sample-list SAMPLE_LIST] [--ploidy PLOIDY]
+                               [--ploidy PLOIDY]
                                [--sample-ploidy SAMPLE_PLOIDY]
                                [--inbreeding INBREEDING]
                                [--sample-inbreeding SAMPLE_INBREEDING]
                                [--base-error-rate BASE_ERROR_RATE]
-                               [--ignore-base-phred-scores]
+                               [--use-base-phred-scores]
                                [--mapping-quality MAPPING_QUALITY]
                                [--keep-duplicate-reads] [--keep-qcfail-reads]
                                [--keep-supplementary-reads]
                                [--read-group-field READ_GROUP_FIELD]
-                               [--genotype-likelihoods]
-                               [--genotype-posteriors] [--cores CORES]
+                               [--report [REPORT ...]] [--cores CORES]
                                [--mcmc-chains MCMC_CHAINS]
                                [--mcmc-steps MCMC_STEPS]
                                [--mcmc-burn MCMC_BURN] [--mcmc-seed MCMC_SEED]
@@ -23,7 +22,7 @@ usage: MCMC haplotype assembly [-h] [--region REGION] [--region-id REGION_ID]
                                [--mcmc-recombination-step-probability MCMC_RECOMBINATION_STEP_PROBABILITY]
                                [--mcmc-dosage-step-probability MCMC_DOSAGE_STEP_PROBABILITY]
                                [--mcmc-partial-dosage-step-probability MCMC_PARTIAL_DOSAGE_STEP_PROBABILITY]
-                               [--mcmc-temperatures [MCMC_TEMPERATURES [MCMC_TEMPERATURES ...]]]
+                               [--mcmc-temperatures [MCMC_TEMPERATURES ...]]
                                [--sample-mcmc-temperatures SAMPLE_MCMC_TEMPERATURES]
                                [--haplotype-posterior-threshold HAPLOTYPE_POSTERIOR_THRESHOLD]
 
@@ -49,8 +48,7 @@ optional arguments:
                         within this file.
   --reference REFERENCE
                         Indexed fasta file containing the reference genome.
-  --bam [BAM [BAM ...]]
-                        A list of 0 or more bam files. All samples found
+  --bam [BAM ...]       A list of 0 or more bam files. All samples found
                         within the listed bam files will be genotypes unless
                         the --sample-list parameter is used.
   --bam-list BAM_LIST   A file containing a list of bam file paths (one per
@@ -65,12 +63,6 @@ optional arguments:
                         parameters when running many small jobs. An error will
                         be thrown if a sample is not found within its
                         specified bam file.
-  --sample-list SAMPLE_LIST
-                        Optionally specify a file containing a list of samples
-                        to genotype (one sample id per line). This file also
-                        specifies the sample order in the output. If not
-                        specified, all samples in the input bam files will be
-                        genotyped.
   --ploidy PLOIDY       Default ploidy for all samples (default = 2). This
                         value is used for all samples which are not specified
                         using the --sample-ploidy parameter
@@ -94,15 +86,15 @@ optional arguments:
                         1].
   --base-error-rate BASE_ERROR_RATE
                         Expected base error rate of read sequences (default =
-                        0.0). This is used in addition to base phred-scores by
-                        default however base phred-scores can be ignored using
-                        the --ignore-base-phred-scores flag.
-  --ignore-base-phred-scores
-                        Flag: Ignore base phred-scores as a source of base
-                        error rate. This can improve MCMC speed by allowing
-                        for greater de-duplication of reads however an error
-                        rate > 0.0 must be specified with the --base-error-
-                        rate argument.
+                        0.0024). The default value comes from Pfeiffer et al
+                        2018 and is a general estimate for Illumina short
+                        reads.
+  --use-base-phred-scores
+                        Flag: use base phred-scores as a source of base error
+                        rate. This will use the phred-encoded per base scores
+                        in addition to the general error rate specified by the
+                        --base-error-rate argument. Using this option can slow
+                        down assembly speed.
   --mapping-quality MAPPING_QUALITY
                         Minimum mapping quality of reads used in assembly
                         (default = 20).
@@ -118,11 +110,10 @@ optional arguments:
                         Read group field to use as sample id (default = "SM").
                         The chosen field determines tha sample ids required in
                         other input files e.g. the --sample-list argument.
-  --genotype-likelihoods
-                        Flag: Report genotype likelihoods in the GL VCF field.
-  --genotype-posteriors
-                        Flag: Report genotype posterior probabilities in the
-                        GP VCF field.
+  --report [REPORT ...]
+                        Extra fields to report within the output VCF: GP =
+                        genotype posterior probabilities; GL = genotype
+                        likelihoods.
   --cores CORES         Number of cpu cores to use (default = 1).
   --mcmc-chains MCMC_CHAINS
                         Number of independent MCMC chains per assembly
@@ -166,7 +157,7 @@ optional arguments:
                         Probability of performing a within-interval dosage
                         sub-step during each step of the MCMC. (default =
                         0.5).
-  --mcmc-temperatures [MCMC_TEMPERATURES [MCMC_TEMPERATURES ...]]
+  --mcmc-temperatures [MCMC_TEMPERATURES ...]
                         A list of inverse-temperatures to use for parallel
                         tempered chains. These values must be between 0 and 1
                         and will automatically be sorted in ascending order.

--- a/cli-call-exact-help.txt
+++ b/cli-call-exact-help.txt
@@ -82,5 +82,5 @@ optional arguments:
   --report [REPORT ...]
                         Extra fields to report within the output VCF: GP =
                         genotype posterior probabilities; GL = genotype
-                        likelihoods.
+                        likelihoods; AFP = posterior mean allele frequencies.
   --cores CORES         Number of cpu cores to use (default = 1).

--- a/cli-call-exact-help.txt
+++ b/cli-call-exact-help.txt
@@ -1,26 +1,23 @@
 usage: Exact haplotype calling [-h] [--haplotypes HAPLOTYPES]
-                               [--bam [BAM [BAM ...]]] [--bam-list BAM_LIST]
-                               [--sample-bam SAMPLE_BAM]
-                               [--sample-list SAMPLE_LIST] [--ploidy PLOIDY]
+                               [--bam [BAM ...]] [--bam-list BAM_LIST]
+                               [--sample-bam SAMPLE_BAM] [--ploidy PLOIDY]
                                [--sample-ploidy SAMPLE_PLOIDY]
                                [--inbreeding INBREEDING]
                                [--sample-inbreeding SAMPLE_INBREEDING]
                                [--base-error-rate BASE_ERROR_RATE]
-                               [--ignore-base-phred-scores]
+                               [--use-base-phred-scores]
                                [--mapping-quality MAPPING_QUALITY]
                                [--keep-duplicate-reads] [--keep-qcfail-reads]
                                [--keep-supplementary-reads]
                                [--read-group-field READ_GROUP_FIELD]
-                               [--genotype-likelihoods]
-                               [--genotype-posteriors] [--cores CORES]
+                               [--report [REPORT ...]] [--cores CORES]
 
 optional arguments:
   -h, --help            show this help message and exit
   --haplotypes HAPLOTYPES
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
-  --bam [BAM [BAM ...]]
-                        A list of 0 or more bam files. All samples found
+  --bam [BAM ...]       A list of 0 or more bam files. All samples found
                         within the listed bam files will be genotypes unless
                         the --sample-list parameter is used.
   --bam-list BAM_LIST   A file containing a list of bam file paths (one per
@@ -35,12 +32,6 @@ optional arguments:
                         parameters when running many small jobs. An error will
                         be thrown if a sample is not found within its
                         specified bam file.
-  --sample-list SAMPLE_LIST
-                        Optionally specify a file containing a list of samples
-                        to genotype (one sample id per line). This file also
-                        specifies the sample order in the output. If not
-                        specified, all samples in the input bam files will be
-                        genotyped.
   --ploidy PLOIDY       Default ploidy for all samples (default = 2). This
                         value is used for all samples which are not specified
                         using the --sample-ploidy parameter
@@ -64,15 +55,15 @@ optional arguments:
                         1].
   --base-error-rate BASE_ERROR_RATE
                         Expected base error rate of read sequences (default =
-                        0.0). This is used in addition to base phred-scores by
-                        default however base phred-scores can be ignored using
-                        the --ignore-base-phred-scores flag.
-  --ignore-base-phred-scores
-                        Flag: Ignore base phred-scores as a source of base
-                        error rate. This can improve MCMC speed by allowing
-                        for greater de-duplication of reads however an error
-                        rate > 0.0 must be specified with the --base-error-
-                        rate argument.
+                        0.0024). The default value comes from Pfeiffer et al
+                        2018 and is a general estimate for Illumina short
+                        reads.
+  --use-base-phred-scores
+                        Flag: use base phred-scores as a source of base error
+                        rate. This will use the phred-encoded per base scores
+                        in addition to the general error rate specified by the
+                        --base-error-rate argument. Using this option can slow
+                        down assembly speed.
   --mapping-quality MAPPING_QUALITY
                         Minimum mapping quality of reads used in assembly
                         (default = 20).
@@ -88,9 +79,8 @@ optional arguments:
                         Read group field to use as sample id (default = "SM").
                         The chosen field determines tha sample ids required in
                         other input files e.g. the --sample-list argument.
-  --genotype-likelihoods
-                        Flag: Report genotype likelihoods in the GL VCF field.
-  --genotype-posteriors
-                        Flag: Report genotype posterior probabilities in the
-                        GP VCF field.
+  --report [REPORT ...]
+                        Extra fields to report within the output VCF: GP =
+                        genotype posterior probabilities; GL = genotype
+                        likelihoods.
   --cores CORES         Number of cpu cores to use (default = 1).

--- a/cli-call-help.txt
+++ b/cli-call-help.txt
@@ -86,7 +86,7 @@ optional arguments:
   --report [REPORT ...]
                         Extra fields to report within the output VCF: GP =
                         genotype posterior probabilities; GL = genotype
-                        likelihoods.
+                        likelihoods; AFP = posterior mean allele frequencies.
   --cores CORES         Number of cpu cores to use (default = 1).
   --mcmc-chains MCMC_CHAINS
                         Number of independent MCMC chains per assembly

--- a/cli-call-help.txt
+++ b/cli-call-help.txt
@@ -1,18 +1,17 @@
-usage: MCMC haplotype calling [-h] [--haplotypes HAPLOTYPES]
-                              [--bam [BAM [BAM ...]]] [--bam-list BAM_LIST]
-                              [--sample-bam SAMPLE_BAM]
-                              [--sample-list SAMPLE_LIST] [--ploidy PLOIDY]
+usage: MCMC haplotype calling [-h] [--haplotypes HAPLOTYPES] [--bam [BAM ...]]
+                              [--bam-list BAM_LIST] [--sample-bam SAMPLE_BAM]
+                              [--ploidy PLOIDY]
                               [--sample-ploidy SAMPLE_PLOIDY]
                               [--inbreeding INBREEDING]
                               [--sample-inbreeding SAMPLE_INBREEDING]
                               [--base-error-rate BASE_ERROR_RATE]
-                              [--ignore-base-phred-scores]
+                              [--use-base-phred-scores]
                               [--mapping-quality MAPPING_QUALITY]
                               [--keep-duplicate-reads] [--keep-qcfail-reads]
                               [--keep-supplementary-reads]
                               [--read-group-field READ_GROUP_FIELD]
-                              [--genotype-likelihoods] [--genotype-posteriors]
-                              [--cores CORES] [--mcmc-chains MCMC_CHAINS]
+                              [--report [REPORT ...]] [--cores CORES]
+                              [--mcmc-chains MCMC_CHAINS]
                               [--mcmc-steps MCMC_STEPS]
                               [--mcmc-burn MCMC_BURN] [--mcmc-seed MCMC_SEED]
                               [--mcmc-chain-incongruence-threshold MCMC_CHAIN_INCONGRUENCE_THRESHOLD]
@@ -22,8 +21,7 @@ optional arguments:
   --haplotypes HAPLOTYPES
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
-  --bam [BAM [BAM ...]]
-                        A list of 0 or more bam files. All samples found
+  --bam [BAM ...]       A list of 0 or more bam files. All samples found
                         within the listed bam files will be genotypes unless
                         the --sample-list parameter is used.
   --bam-list BAM_LIST   A file containing a list of bam file paths (one per
@@ -38,12 +36,6 @@ optional arguments:
                         parameters when running many small jobs. An error will
                         be thrown if a sample is not found within its
                         specified bam file.
-  --sample-list SAMPLE_LIST
-                        Optionally specify a file containing a list of samples
-                        to genotype (one sample id per line). This file also
-                        specifies the sample order in the output. If not
-                        specified, all samples in the input bam files will be
-                        genotyped.
   --ploidy PLOIDY       Default ploidy for all samples (default = 2). This
                         value is used for all samples which are not specified
                         using the --sample-ploidy parameter
@@ -67,15 +59,15 @@ optional arguments:
                         1].
   --base-error-rate BASE_ERROR_RATE
                         Expected base error rate of read sequences (default =
-                        0.0). This is used in addition to base phred-scores by
-                        default however base phred-scores can be ignored using
-                        the --ignore-base-phred-scores flag.
-  --ignore-base-phred-scores
-                        Flag: Ignore base phred-scores as a source of base
-                        error rate. This can improve MCMC speed by allowing
-                        for greater de-duplication of reads however an error
-                        rate > 0.0 must be specified with the --base-error-
-                        rate argument.
+                        0.0024). The default value comes from Pfeiffer et al
+                        2018 and is a general estimate for Illumina short
+                        reads.
+  --use-base-phred-scores
+                        Flag: use base phred-scores as a source of base error
+                        rate. This will use the phred-encoded per base scores
+                        in addition to the general error rate specified by the
+                        --base-error-rate argument. Using this option can slow
+                        down assembly speed.
   --mapping-quality MAPPING_QUALITY
                         Minimum mapping quality of reads used in assembly
                         (default = 20).
@@ -91,11 +83,10 @@ optional arguments:
                         Read group field to use as sample id (default = "SM").
                         The chosen field determines tha sample ids required in
                         other input files e.g. the --sample-list argument.
-  --genotype-likelihoods
-                        Flag: Report genotype likelihoods in the GL VCF field.
-  --genotype-posteriors
-                        Flag: Report genotype posterior probabilities in the
-                        GP VCF field.
+  --report [REPORT ...]
+                        Extra fields to report within the output VCF: GP =
+                        genotype posterior probabilities; GL = genotype
+                        likelihoods.
   --cores CORES         Number of cpu cores to use (default = 1).
   --mcmc-chains MCMC_CHAINS
                         Number of independent MCMC chains per assembly

--- a/mchap/application/arguments.py
+++ b/mchap/application/arguments.py
@@ -315,7 +315,8 @@ report = Parameter(
         help=(
             "Extra fields to report within the output VCF: "
             "GP = genotype posterior probabilities; "
-            "GL = genotype likelihoods."
+            "GL = genotype likelihoods; "
+            "AFP = posterior mean allele frequencies."
         ),
     ),
 )

--- a/mchap/application/baseclass.py
+++ b/mchap/application/baseclass.py
@@ -314,10 +314,16 @@ class program(object):
             data.infodata["DP"] = np.nansum(list(data.sampledata["DP"].values()))
         # total read count
         data.infodata["RCOUNT"] = np.nansum(list(data.sampledata["RCOUNT"].values()))
+        # population mean posterior allele frequencies
         if "AFP" in data.infofields:
-            data.infodata["AFP"] = np.mean(
-                list(data.sampledata["AFP"].values()), axis=0
-            ).round(self.precision)
+            # need to weight frequencies of each individual by ploidy
+            pop_ploidy = 0
+            pop_total = np.zeros(len(data.columndata["ALTS"]) + 1, float)
+            for sample, freqs in data.sampledata["AFP"].items():
+                ploidy = self.sample_ploidy[sample]
+                pop_ploidy += ploidy
+                pop_total += freqs * ploidy
+            data.infodata["AFP"] = (pop_total / pop_ploidy).round(self.precision)
         return data
 
     def call_locus(self, locus):

--- a/mchap/application/baseclass.py
+++ b/mchap/application/baseclass.py
@@ -76,7 +76,7 @@ class program(object):
             "END",
             "NVAR",
             "SNVPOS",
-        ]
+        ] + [f for f in ["AFP"] if f in self.report_fields]
         return infofields
 
     def format_fields(self):
@@ -92,11 +92,7 @@ class program(object):
             "GPM",
             "PHPM",
             "MCI",
-        ]
-        if "GL" in self.report_fields:
-            formatfields += ["GL"]
-        if "GP" in self.report_fields:
-            formatfields += ["GP"]
+        ] + [f for f in ["GP", "GL", "AFP", "DS"] if f in self.report_fields]
         return formatfields
 
     def loci(self):
@@ -284,7 +280,8 @@ class program(object):
         -------
         data : LocusAssemblyData
             With columndata fields: "REF" "ALTS" and infodata fields:
-            "END", "NVAR", "SNVPOS", "AC", "AN", "NS", "DP", "RCOUNT".
+            "END", "NVAR", "SNVPOS", "AC", "AN", "NS", "DP", "RCOUNT"
+            and "AFP" if specified.
         """
         # postions
         data.infodata["END"] = data.locus.stop
@@ -317,6 +314,10 @@ class program(object):
             data.infodata["DP"] = np.nansum(list(data.sampledata["DP"].values()))
         # total read count
         data.infodata["RCOUNT"] = np.nansum(list(data.sampledata["RCOUNT"].values()))
+        if "AFP" in data.infofields:
+            data.infodata["AFP"] = np.mean(
+                list(data.sampledata["AFP"].values()), axis=0
+            ).round(self.precision)
         return data
 
     def call_locus(self, locus):

--- a/mchap/application/call.py
+++ b/mchap/application/call.py
@@ -66,6 +66,7 @@ class program(baseclass.program):
             "MCI",
             "GL",
             "GP",
+            "AFP",
         ]:
             data.sampledata[field] = dict()
         haplotypes = data.locus.encode_haplotypes()
@@ -106,6 +107,15 @@ class program(baseclass.program):
                 )
                 data.sampledata["PHQ"][sample] = qual_of_prob(phenotype_prob)
                 data.sampledata["MCI"][sample] = incongruence
+
+                # posterior allele frequencies if requested
+                if "AFP" in data.formatfields:
+                    frequencies = np.zeros(len(haplotypes))
+                    alleles, counts = np.unique(trace.genotypes, return_counts=True)
+                    frequencies[alleles] = counts / counts.sum()
+                    data.sampledata["AFP"][sample] = np.round(
+                        frequencies, self.precision
+                    )
 
                 # genotype posteriors if requested
                 if "GP" in data.formatfields:

--- a/mchap/application/call_exact.py
+++ b/mchap/application/call_exact.py
@@ -79,11 +79,7 @@ class program(baseclass.program):
                 read_counts = read_counts = data.sampledata["read_dist_counts"][sample]
 
                 # call haplotypes
-                if (
-                    ("GL" in data.formatfields)
-                    or ("GP" in data.formatfields)
-                    or ("AFP" in data.formatfields)
-                ):
+                if ("GL" in data.formatfields) or ("GP" in data.formatfields):
                     # calculate full arrays
                     llks = genotype_likelihoods(
                         reads=reads,
@@ -122,14 +118,20 @@ class program(baseclass.program):
 
                 else:
                     # use low memory calculation
-                    alleles, _, genotype_prob, phenotype_prob = posterior_mode(
+                    mode_results = posterior_mode(
                         reads=reads,
                         read_counts=read_counts,
                         haplotypes=haplotypes,
                         ploidy=ploidy,
                         inbreeding=inbreeding,
                         return_phenotype_prob=True,
+                        return_posterior_frequencies="AFP" in data.formatfields,
                     )
+                    alleles, _, genotype_prob, phenotype_prob = mode_results[0:4]
+                    if "AFP" in data.formatfields:
+                        data.sampledata["AFP"][sample] = np.round(
+                            mode_results[-1], self.precision
+                        )
 
                 # store variables
                 data.sampledata["alleles"][sample] = alleles

--- a/mchap/application/call_exact.py
+++ b/mchap/application/call_exact.py
@@ -10,7 +10,7 @@ from mchap.application.arguments import (
     collect_call_exact_program_arguments,
 )
 from mchap.calling.exact import (
-    call_posterior_mode,
+    posterior_mode,
     genotype_likelihoods,
     genotype_posteriors,
     alternate_dosage_posteriors,
@@ -122,7 +122,7 @@ class program(baseclass.program):
 
                 else:
                     # use low memory calculation
-                    alleles, _, genotype_prob, phenotype_prob = call_posterior_mode(
+                    alleles, _, genotype_prob, phenotype_prob = posterior_mode(
                         reads=reads,
                         read_counts=read_counts,
                         haplotypes=haplotypes,

--- a/mchap/assemble/classes.py
+++ b/mchap/assemble/classes.py
@@ -165,6 +165,36 @@ class PosteriorGenotypeDistribution(object):
         else:
             return uhaps, uprobs
 
+    def allele_frequencies(self, dosage=False):
+        """Calculate posterior frequency of haplotype alleles.
+
+        Parameters
+        ----------
+        dosage : bool
+            If true then frequencies will be multiplied by ploidy
+            resulting in the posterior allele dosage.
+
+        Returns
+        -------
+        haplotypes : ndarray, int, shape (n_haplotypes, n_base)
+            Unique haplotypes.
+        frequencies : ndarray, float, shape (n_haplotypes, )
+            Posterior frequencies of haplotype alleles.
+        """
+        n_gen, ploidy, n_base = self.genotypes.shape
+        haps = self.genotypes.reshape(n_gen * ploidy, n_base)
+        uhaps = mset.unique(haps)
+        ufreqs = np.zeros(len(uhaps), float)
+        freqs = {h.tobytes(): 0.0 for h in uhaps}
+        for gen, prob in zip(self.genotypes, self.probabilities):
+            for hap in gen:
+                freqs[hap.tobytes()] += prob
+        for i, hap in enumerate(uhaps):
+            ufreqs[i] = freqs[hap.tobytes()]
+        if dosage is False:
+            ufreqs /= ploidy
+        return uhaps, ufreqs
+
 
 @dataclass
 class PhenotypeDistribution(object):

--- a/mchap/assemble/haplotype_calling.py
+++ b/mchap/assemble/haplotype_calling.py
@@ -24,7 +24,11 @@ def call_posterior_haplotypes(posteriors, threshold=0.01):
     # iterate through genotype posterors
     for post in posteriors:
         # include haps based on probability of occurrence
-        haps, probs, weights = post.haplotype_probabilities(return_weighted=True)
+        (
+            haps,
+            probs,
+        ) = post.allele_occurrence()
+        _, weights = post.allele_frequencies(dosage=True)
         idx = probs >= threshold
         # order haps based on weighted prob
         haps = haps[idx]

--- a/mchap/calling/exact.py
+++ b/mchap/calling/exact.py
@@ -234,6 +234,21 @@ def genotype_posteriors(log_likelihoods, ploidy, n_alleles, inbreeding=0):
     return normalise_log_probs(posteriors)
 
 
+@njit(cache=True)
+def posterior_allele_frequencies(posteriors, ploidy, n_alleles, dosage=False):
+    n_genotypes = len(posteriors)
+    freqs = np.zeros(n_alleles, dtype=np.float32)
+    genotype = np.zeros(ploidy, np.int64)
+    for i in range(n_genotypes):
+        p = posteriors[i]
+        for j in range(ploidy):
+            freqs[genotype[j]] += p
+        increment_genotype(genotype)
+    if dosage is False:
+        freqs /= ploidy
+    return freqs
+
+
 def alternate_dosage_posteriors(genotype_alleles, probabilities):
     """Extract alternate dosage probabilities based on allelic phenotype.
 

--- a/mchap/io/vcf/formatfields.py
+++ b/mchap/io/vcf/formatfields.py
@@ -64,6 +64,9 @@ GL = FormatField(id="GL", number="G", type="Float", descr="Genotype likelihoods"
 GP = FormatField(
     id="GP", number="G", type="Float", descr="Genotype posterior probabilities"
 )
+AFP = FormatField(
+    id="AFP", number="R", type="Float", descr="Posterior allele frequencies"
+)
 MCI = FormatField(
     id="MCI",
     number=1,
@@ -99,6 +102,7 @@ HEADER_FORMAT_FIELDS = dict(
     AD=AD,
     GL=GL,
     GP=GP,
+    AFP=AFP,
     MCI=MCI,
     KMERCOV=KMERCOV,
     MCAP=MCAP,

--- a/mchap/io/vcf/formatfields.py
+++ b/mchap/io/vcf/formatfields.py
@@ -65,7 +65,7 @@ GP = FormatField(
     id="GP", number="G", type="Float", descr="Genotype posterior probabilities"
 )
 AFP = FormatField(
-    id="AFP", number="R", type="Float", descr="Posterior allele frequencies"
+    id="AFP", number="R", type="Float", descr="Posterior mean allele frequencies"
 )
 MCI = FormatField(
     id="MCI",

--- a/mchap/io/vcf/infofields.py
+++ b/mchap/io/vcf/infofields.py
@@ -31,6 +31,9 @@ AN = InfoField(
     descr="Total number of alleles in called genotypes",
 )
 AF = InfoField(id="AF", number="A", type="Float", descr="Allele Frequency")
+AFP = InfoField(
+    id="AFP", number="R", type="Float", descr="Posterior allele frequencies"
+)
 AA = InfoField(id="AA", number=1, type="String", descr="Ancestral allele")
 END = InfoField(id="END", number=1, type="Integer", descr="End position on CHROM")
 NVAR = InfoField(
@@ -64,6 +67,7 @@ HEADER_INFO_FIELDS = dict(
     AC=AC,
     AN=AN,
     AF=AF,
+    AFP=AFP,
     AA=AA,
     END=END,
     NVAR=NVAR,

--- a/mchap/io/vcf/infofields.py
+++ b/mchap/io/vcf/infofields.py
@@ -32,7 +32,7 @@ AN = InfoField(
 )
 AF = InfoField(id="AF", number="A", type="Float", descr="Allele Frequency")
 AFP = InfoField(
-    id="AFP", number="R", type="Float", descr="Posterior allele frequencies"
+    id="AFP", number="R", type="Float", descr="Posterior mean allele frequencies"
 )
 AA = InfoField(id="AA", number=1, type="String", descr="Ancestral allele")
 END = InfoField(id="END", number=1, type="Integer", descr="End position on CHROM")

--- a/mchap/tests/test_application_assemble.py
+++ b/mchap/tests/test_application_assemble.py
@@ -329,6 +329,11 @@ def test_Program__run(cli_extra, output_vcf):
             "simple.output.mixed_depth.assemble.vcf",
         ),
         (
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            ["--report", "AFP"],
+            "simple.output.mixed_depth.assemble.frequencies.vcf",
+        ),
+        (
             ["simple.sample1.bam", "simple.sample2.bam", "simple.sample3.bam"],
             [
                 "--haplotype-posterior-threshold",

--- a/mchap/tests/test_application_call.py
+++ b/mchap/tests/test_application_call.py
@@ -19,6 +19,14 @@ from mchap.application.call import program
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
+                "AFP",
+            ],
+            "simple.output.mixed_depth.call.frequencies.vcf",
+        ),
+        (
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            [
+                "--report",
                 "GL",
                 "--base-error-rate",
                 "0.0",

--- a/mchap/tests/test_application_call_exact.py
+++ b/mchap/tests/test_application_call_exact.py
@@ -19,6 +19,14 @@ from mchap.application.call_exact import program
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
+                "AFP",
+            ],
+            "simple.output.mixed_depth.call-exact.frequencies.vcf",
+        ),
+        (
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            [
+                "--report",
                 "GL",
                 "--base-error-rate",
                 "0.0",

--- a/mchap/tests/test_assemble/test_classes.py
+++ b/mchap/tests/test_assemble/test_classes.py
@@ -140,7 +140,7 @@ def test_PhenotypeDistribution___mode_genotype():
     assert expect[1] == actual[1]
 
 
-def test_PosteriorGenotypeDistribution__haplotype_probabilities():
+def test_PosteriorGenotypeDistribution__allele_occurrence():
     array = np.array(
         [
             [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
@@ -168,12 +168,12 @@ def test_PosteriorGenotypeDistribution__haplotype_probabilities():
             0.1,
         ]
     )
-    actual_haps, actual_probs = dist.haplotype_probabilities()
+    actual_haps, actual_probs = dist.allele_occurrence()
     np.testing.assert_array_equal(actual_haps, expect_haps)
     np.testing.assert_array_almost_equal(actual_probs, expect_probs)
 
 
-def test_PosteriorGenotypeDistribution__haplotype_probabilities__weights():
+def test_PosteriorGenotypeDistribution__allele_frequencies():
     array = np.array(
         [
             [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
@@ -193,15 +193,7 @@ def test_PosteriorGenotypeDistribution__haplotype_probabilities__weights():
             [0, 1, 0],
         ]
     )
-    expect_probs = np.array(
-        [
-            0.05 + 0.65 + 0.2 + 0.1,
-            0.65 + 0.2 + 0.1,
-            0.2 + 0.1,
-            0.1,
-        ]
-    )
-    expect_weights = np.array(
+    expect_freqs = np.array(
         [
             0.05 * 1 + 0.65 * (3 / 4) + 0.2 * (2 / 4) + 0.1 * (1 / 4),
             0.65 * (1 / 4) + 0.2 * (1 / 4) + 0.1 * (1 / 4),
@@ -209,12 +201,9 @@ def test_PosteriorGenotypeDistribution__haplotype_probabilities__weights():
             0.1 * (1 / 4),
         ]
     )
-    actual_haps, actual_probs, actual_weights = dist.haplotype_probabilities(
-        return_weighted=True
-    )
+    actual_haps, actual_freqs = dist.allele_frequencies()
     np.testing.assert_array_equal(actual_haps, expect_haps)
-    np.testing.assert_array_almost_equal(actual_probs, expect_probs)
-    np.testing.assert_array_almost_equal(actual_weights, expect_weights)
+    np.testing.assert_array_almost_equal(actual_freqs, expect_freqs)
 
 
 @pytest.mark.parametrize(

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.assemble.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.assemble.frequencies.vcf
@@ -1,8 +1,8 @@
 ##fileformat=VCFv4.3
-##fileDate=20210420
+##fileDate=20220406
 ##source=mchap v0.5.1
 ##phasing=None
-##commandline="mchap assemble --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --targets simple.bed.gz --variants simple.vcf.gz --reference simple.fasta --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11"
+##commandline="mchap assemble --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --targets simple.bed.gz --variants simple.vcf.gz --reference simple.fasta --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11 --report AFP"
 ##randomseed=11
 ##contig=<ID=CHR1,length=60>
 ##contig=<ID=CHR2,length=60>
@@ -16,6 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -27,8 +28,9 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
-CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/1/2:7:8:13:20:40:0:1,1,1:0.785:0.835:0	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0	0/0/0/2:4:5:13:20:40:0:1,1,1:0.619:0.698:0
-CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0
-CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/2:6:8:14:24:28:0:1,1,.:0.72:0.84:0	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:0	0/1/1/3:7:13:14:24:28:0:1,1,.:0.801:0.949:0
-CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.533,0.253,0.175	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:7:8:13:20:40:0:1,1,1:0.785:0.835:0:0.446,0.257,0.255	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0:0.5,0.5,0	0/0/0/2:4:5:13:20:40:0:1,1,1:0.619:0.698:0:0.653,0.002,0.27
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10;AFP=0.481,0.235,0.178,0.093	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/2:6:8:14:24:28:0:1,1,.:0.72:0.84:0:0.68,0.004,0.28,0.006	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:0:0.5,0.25,0.25,0	0/1/1/3:7:13:14:24:28:0:1,1,.:0.801:0.949:0:0.262,0.45,0.004,0.274
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.assemble.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.assemble.frequencies.vcf
@@ -16,7 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
-##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -28,7 +28,7 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
-##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
 CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.533,0.253,0.175	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:7:8:13:20:40:0:1,1,1:0.785:0.835:0:0.446,0.257,0.255	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0:0.5,0.5,0	0/0/0/2:4:5:13:20:40:0:1,1,1:0.619:0.698:0:0.653,0.002,0.27
 CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.vcf
@@ -1,9 +1,9 @@
 ##fileformat=VCFv4.3
-##fileDate=20210420
+##fileDate=20220406
 ##source=mchap v0.5.1
 ##phasing=None
-##commandline="mchap assemble --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --targets simple.bed.gz --variants simple.vcf.gz --reference simple.fasta --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11"
-##randomseed=11
+##commandline="mchap call-exact --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --haplotypes simple.output.mixed_depth.assemble.vcf --report AFP"
+##randomseed=None
 ##contig=<ID=CHR1,length=60>
 ##contig=<ID=CHR2,length=60>
 ##contig=<ID=CHR3,length=60>
@@ -16,6 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -27,8 +28,9 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
-CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/1/2:7:8:13:20:40:0:1,1,1:0.785:0.835:0	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0	0/0/0/2:4:5:13:20:40:0:1,1,1:0.619:0.698:0
-CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0
-CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/2:6:8:14:24:28:0:1,1,.:0.72:0.84:0	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:0	0/1/1/3:7:13:14:24:28:0:1,1,.:0.801:0.949:0
-CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.57,0.253,0.177	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:12:60:13:20:40:0:1,1,1:0.941:1:.:0.485,0.257,0.257	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:.:0.5,0.5,0	0/0/0/2:10:22:13:20:40:0:1,1,1:0.896:0.994:.:0.724,0.002,0.275
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:.:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10;AFP=0.489,0.237,0.18,0.094	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/2:7:14:14:24:28:0:1,1,.:0.812:0.962:.:0.703,0.005,0.288,0.005	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:.:0.5,0.25,0.25,0	0/1/1/3:8:21:14:24:28:0:1,1,.:0.827:0.992:.:0.265,0.457,0.002,0.276
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:.:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.vcf
@@ -16,7 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
-##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -28,7 +28,7 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
-##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
 CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.57,0.253,0.177	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:12:60:13:20:40:0:1,1,1:0.941:1:.:0.485,0.257,0.257	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:.:0.5,0.5,0	0/0/0/2:10:22:13:20:40:0:1,1,1:0.896:0.994:.:0.724,0.002,0.275
 CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:.:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:.:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.vcf
@@ -16,7 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
-##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -28,7 +28,7 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
-##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
 CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.57,0.253,0.177	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:13:60:13:20:40:0:1,1,1:0.952:1:0:0.488,0.256,0.256	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0:0.5,0.5,0	0/0/0/2:10:19:13:20:40:0:1,1,1:0.894:0.989:0:0.723,0.003,0.274
 CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.vcf
@@ -1,8 +1,8 @@
 ##fileformat=VCFv4.3
-##fileDate=20210420
+##fileDate=20220406
 ##source=mchap v0.5.1
 ##phasing=None
-##commandline="mchap assemble --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --targets simple.bed.gz --variants simple.vcf.gz --reference simple.fasta --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11"
+##commandline="mchap call --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --haplotypes simple.output.deep.assemble.vcf --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11 --report AFP"
 ##randomseed=11
 ##contig=<ID=CHR1,length=60>
 ##contig=<ID=CHR2,length=60>
@@ -16,6 +16,7 @@
 ##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
 ##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
 ##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
 ##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
@@ -27,8 +28,9 @@
 ##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
 ##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
 ##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior allele frequencies">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
-CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/1/2:7:8:13:20:40:0:1,1,1:0.785:0.835:0	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0	0/0/0/2:4:5:13:20:40:0:1,1,1:0.619:0.698:0
-CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0
-CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/2:6:8:14:24:28:0:1,1,.:0.72:0.84:0	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:0	0/1/1/3:7:13:14:24:28:0:1,1,.:0.801:0.949:0
-CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.57,0.253,0.177	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/1/2:13:60:13:20:40:0:1,1,1:0.952:1:0:0.488,0.256,0.256	0/0/1/1:60:60:133:200:400:0:1,1,1:1:1:0:0.5,0.5,0	0/0/0/2:10:19:13:20:40:0:1,1,1:0.894:0.989:0:0.723,0.003,0.274
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:240:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:24:0:0:.,.,.:1:1:0:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10;AFP=0.491,0.235,0.18,0.094	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/2:7:15:14:24:28:0:1,1,.:0.821:0.969:0:0.705,0.004,0.287,0.004	0/0/1/2:60:60:140:240:280:0:1,1,.:1:1:0:0.5,0.25,0.25,0	0/1/1/3:7:21:14:24:28:0:1,1,.:0.806:0.992:0:0.268,0.452,0.002,0.279
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:KMERCOV:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.,.,.:1:1:0:1


### PR DESCRIPTION
Fixes #103 

- Addition of the AFP field(s) for both sample and population posterior allele frequencies.
- Note that this doesn't add posterior dosage yet because there are some questions that need to be resolved there.
- This also improves performance of calculating posterior allele frequencies and posterior allele occurrence.
- Also updates the help text in the repo which was missed in an earlier PR.
