### PR TITLE
Population prior allele frequencies

### DIFF
--- a/cli-call-exact-help.txt
+++ b/cli-call-exact-help.txt
@@ -21,12 +21,12 @@ optional arguments:
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
   --haplotype-frequencies HAPLOTYPE_FREQUENCIES
-                        Specify an INFO field within the input VCF file to use
-                        for approximation of prior allele frequencies. This
-                        can be any numerical field of length 'R' and these
-                        values will automatically be normalized. This
-                        parameter has no affect on the output but is necessary
-                        for some other parameters.
+                        Optionally specify an INFO field within the input VCF
+                        file to designate as allele frequencies for the input
+                        haplotypes. This can be any numerical field of length
+                        'R' and these values will automatically be normalized.
+                        This parameter has no affect on the output by itself
+                        but is required by some other parameters.
   --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
                         Optionally ignore haplotypes from the input VCF file
                         if their frequency within that file is less than the

--- a/cli-call-exact-help.txt
+++ b/cli-call-exact-help.txt
@@ -1,5 +1,6 @@
 usage: Exact haplotype calling [-h] [--haplotypes HAPLOTYPES]
                                [--haplotype-frequencies HAPLOTYPE_FREQUENCIES]
+                               [--haplotype-frequencies-prior]
                                [--skip-rare-haplotypes SKIP_RARE_HAPLOTYPES]
                                [--bam [BAM ...]] [--bam-list BAM_LIST]
                                [--sample-bam SAMPLE_BAM] [--ploidy PLOIDY]
@@ -27,6 +28,10 @@ optional arguments:
                         'R' and these values will automatically be normalized.
                         This parameter has no affect on the output by itself
                         but is required by some other parameters.
+  --haplotype-frequencies-prior
+                        Flag: Use haplotype frequencies to inform prior
+                        distribution. This requires that the --haplotype-
+                        frequencies parameter is also specified.
   --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
                         Optionally ignore haplotypes from the input VCF file
                         if their frequency within that file is less than the

--- a/cli-call-exact-help.txt
+++ b/cli-call-exact-help.txt
@@ -1,4 +1,6 @@
 usage: Exact haplotype calling [-h] [--haplotypes HAPLOTYPES]
+                               [--haplotype-frequencies HAPLOTYPE_FREQUENCIES]
+                               [--skip-rare-haplotypes SKIP_RARE_HAPLOTYPES]
                                [--bam [BAM ...]] [--bam-list BAM_LIST]
                                [--sample-bam SAMPLE_BAM] [--ploidy PLOIDY]
                                [--sample-ploidy SAMPLE_PLOIDY]
@@ -18,6 +20,18 @@ optional arguments:
   --haplotypes HAPLOTYPES
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
+  --haplotype-frequencies HAPLOTYPE_FREQUENCIES
+                        Specify an INFO field within the input VCF file to use
+                        for approximation of prior allele frequencies. This
+                        can be any numerical field of length 'R' and these
+                        values will automatically be normalized. This
+                        parameter has no affect on the output but is necessary
+                        for some other parameters.
+  --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
+                        Optionally ignore haplotypes from the input VCF file
+                        if their frequency within that file is less than the
+                        specified value. This requires that the --haplotype-
+                        frequencies parameter is also specified.
   --bam [BAM ...]       A list of 0 or more bam files. All samples found
                         within the listed bam files will be genotypes unless
                         the --sample-list parameter is used.

--- a/cli-call-help.txt
+++ b/cli-call-help.txt
@@ -1,6 +1,8 @@
-usage: MCMC haplotype calling [-h] [--haplotypes HAPLOTYPES] [--bam [BAM ...]]
-                              [--bam-list BAM_LIST] [--sample-bam SAMPLE_BAM]
-                              [--ploidy PLOIDY]
+usage: MCMC haplotype calling [-h] [--haplotypes HAPLOTYPES]
+                              [--haplotype-frequencies HAPLOTYPE_FREQUENCIES]
+                              [--skip-rare-haplotypes SKIP_RARE_HAPLOTYPES]
+                              [--bam [BAM ...]] [--bam-list BAM_LIST]
+                              [--sample-bam SAMPLE_BAM] [--ploidy PLOIDY]
                               [--sample-ploidy SAMPLE_PLOIDY]
                               [--inbreeding INBREEDING]
                               [--sample-inbreeding SAMPLE_INBREEDING]
@@ -22,6 +24,18 @@ optional arguments:
   --haplotypes HAPLOTYPES
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
+  --haplotype-frequencies HAPLOTYPE_FREQUENCIES
+                        Specify an INFO field within the input VCF file to use
+                        for approximation of prior allele frequencies. This
+                        can be any numerical field of length 'R' and these
+                        values will automatically be normalized. This
+                        parameter has no affect on the output but is necessary
+                        for some other parameters.
+  --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
+                        Optionally ignore haplotypes from the input VCF file
+                        if their frequency within that file is less than the
+                        specified value. This requires that the --haplotype-
+                        frequencies parameter is also specified.
   --bam [BAM ...]       A list of 0 or more bam files. All samples found
                         within the listed bam files will be genotypes unless
                         the --sample-list parameter is used.

--- a/cli-call-help.txt
+++ b/cli-call-help.txt
@@ -1,5 +1,6 @@
 usage: MCMC haplotype calling [-h] [--haplotypes HAPLOTYPES]
                               [--haplotype-frequencies HAPLOTYPE_FREQUENCIES]
+                              [--haplotype-frequencies-prior]
                               [--skip-rare-haplotypes SKIP_RARE_HAPLOTYPES]
                               [--bam [BAM ...]] [--bam-list BAM_LIST]
                               [--sample-bam SAMPLE_BAM] [--ploidy PLOIDY]
@@ -31,6 +32,10 @@ optional arguments:
                         'R' and these values will automatically be normalized.
                         This parameter has no affect on the output by itself
                         but is required by some other parameters.
+  --haplotype-frequencies-prior
+                        Flag: Use haplotype frequencies to inform prior
+                        distribution. This requires that the --haplotype-
+                        frequencies parameter is also specified.
   --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
                         Optionally ignore haplotypes from the input VCF file
                         if their frequency within that file is less than the

--- a/cli-call-help.txt
+++ b/cli-call-help.txt
@@ -25,12 +25,12 @@ optional arguments:
                         Tabix indexed VCF file containing haplotype/MNP/SNP
                         variants to be re-called among input samples.
   --haplotype-frequencies HAPLOTYPE_FREQUENCIES
-                        Specify an INFO field within the input VCF file to use
-                        for approximation of prior allele frequencies. This
-                        can be any numerical field of length 'R' and these
-                        values will automatically be normalized. This
-                        parameter has no affect on the output but is necessary
-                        for some other parameters.
+                        Optionally specify an INFO field within the input VCF
+                        file to designate as allele frequencies for the input
+                        haplotypes. This can be any numerical field of length
+                        'R' and these values will automatically be normalized.
+                        This parameter has no affect on the output by itself
+                        but is required by some other parameters.
   --skip-rare-haplotypes SKIP_RARE_HAPLOTYPES
                         Optionally ignore haplotypes from the input VCF file
                         if their frequency within that file is less than the

--- a/mchap/application/arguments.py
+++ b/mchap/application/arguments.py
@@ -304,12 +304,12 @@ haplotype_frequencies = Parameter(
         nargs=1,
         default=[None],
         help=(
-            "Specify an INFO field within the input VCF file to use for approximation "
-            "of prior allele frequencies. "
+            "Optionally specify an INFO field within the input VCF file to "
+            "designate as allele frequencies for the input haplotypes. "
             "This can be any numerical field of length 'R' and these "
             "values will automatically be normalized. "
-            "This parameter has no affect on the output but is necessary for some "
-            "other parameters."
+            "This parameter has no affect on the output by itself but "
+            "is required by some other parameters."
         ),
     ),
 )

--- a/mchap/application/arguments.py
+++ b/mchap/application/arguments.py
@@ -314,6 +314,18 @@ haplotype_frequencies = Parameter(
     ),
 )
 
+haplotype_frequencies_prior = BooleanFlag(
+    "--haplotype-frequencies-prior",
+    dict(
+        dest="haplotype_frequencies_prior",
+        action="store_true",
+        help=(
+            "Flag: Use haplotype frequencies to inform prior distribution. "
+            "This requires that the --haplotype-frequencies parameter is also specified."
+        ),
+    ),
+)
+
 skip_rare_haplotypes = Parameter(
     "--skip-rare-haplotypes",
     dict(
@@ -594,11 +606,14 @@ DEFAULT_PARSER_ARGUMENTS = [
     cores,
 ]
 
-CALL_EXACT_PARSER_ARGUMENTS = [
+KNOWN_HAPLOTYPES_ARGUMENTS = [
     haplotypes,
     haplotype_frequencies,
+    haplotype_frequencies_prior,
     skip_rare_haplotypes,
-] + DEFAULT_PARSER_ARGUMENTS
+]
+
+CALL_EXACT_PARSER_ARGUMENTS = KNOWN_HAPLOTYPES_ARGUMENTS + DEFAULT_PARSER_ARGUMENTS
 
 DEFAULT_MCMC_PARSER_ARGUMENTS = DEFAULT_PARSER_ARGUMENTS + [
     mcmc_chains,
@@ -608,11 +623,7 @@ DEFAULT_MCMC_PARSER_ARGUMENTS = DEFAULT_PARSER_ARGUMENTS + [
     mcmc_chain_incongruence_threshold,
 ]
 
-CALL_MCMC_PARSER_ARGUMENTS = [
-    haplotypes,
-    haplotype_frequencies,
-    skip_rare_haplotypes,
-] + DEFAULT_MCMC_PARSER_ARGUMENTS
+CALL_MCMC_PARSER_ARGUMENTS = KNOWN_HAPLOTYPES_ARGUMENTS + DEFAULT_MCMC_PARSER_ARGUMENTS
 
 ASSEMBLE_MCMC_PARSER_ARGUMENTS = (
     [
@@ -835,6 +846,7 @@ def collect_call_exact_program_arguments(arguments):
     data = collect_default_program_arguments(arguments)
     data["vcf"] = arguments.haplotypes[0]
     data["random_seed"] = None
+    data["use_haplotype_frequencies_prior"] = arguments.haplotype_frequencies_prior
     data["haplotype_frequencies_tag"] = arguments.haplotype_frequencies[0]
     data["skip_rare_haplotypes"] = arguments.skip_rare_haplotypes[0]
     return data
@@ -857,6 +869,7 @@ def collect_default_mcmc_program_arguments(arguments):
 def collect_call_mcmc_program_arguments(arguments):
     data = collect_default_mcmc_program_arguments(arguments)
     data["vcf"] = arguments.haplotypes[0]
+    data["use_haplotype_frequencies_prior"] = arguments.haplotype_frequencies_prior
     data["haplotype_frequencies_tag"] = arguments.haplotype_frequencies[0]
     data["skip_rare_haplotypes"] = arguments.skip_rare_haplotypes[0]
     return data

--- a/mchap/application/arguments.py
+++ b/mchap/application/arguments.py
@@ -297,24 +297,33 @@ haplotype_posterior_threshold = Parameter(
     ),
 )
 
-use_assembly_posteriors = BooleanFlag(
-    "--use-assembly-posteriors",
+haplotype_frequencies = Parameter(
+    "--haplotype-frequencies",
     dict(
-        dest="use_assembly_posteriors",
-        action="store_true",
+        type=str,
+        nargs=1,
+        default=[None],
         help=(
-            "Flag: Use posterior probabilities from each individuals "
-            "assembly rather than recomputing posteriors based on the "
-            "observed alleles across all samples. "
-            "These posterior probabilities will be used to call genotypes "
-            ", metrics related to the genotype, and the posterior "
-            "distribution (GP field) if specified. "
-            "This may lead to less robust genotype calls in the presence "
-            "of multi-modality and hence it is recommended to run the "
-            "simulation for longer or using parallel-tempering when "
-            "using this option. "
-            "This option may be more suitable than the default when calling "
-            "haplotypes in unrelated individuals. "
+            "Specify an INFO field within the input VCF file to use for approximation "
+            "of prior allele frequencies. "
+            "This can be any numerical field of length 'R' and these "
+            "values will automatically be normalized. "
+            "This parameter has no affect on the output but is necessary for some "
+            "other parameters."
+        ),
+    ),
+)
+
+skip_rare_haplotypes = Parameter(
+    "--skip-rare-haplotypes",
+    dict(
+        type=float,
+        nargs=1,
+        default=[None],
+        help=(
+            "Optionally ignore haplotypes from the input VCF file if their frequency "
+            "within that file is less than the specified value. "
+            "This requires that the --haplotype-frequencies parameter is also specified."
         ),
     ),
 )
@@ -587,6 +596,8 @@ DEFAULT_PARSER_ARGUMENTS = [
 
 CALL_EXACT_PARSER_ARGUMENTS = [
     haplotypes,
+    haplotype_frequencies,
+    skip_rare_haplotypes,
 ] + DEFAULT_PARSER_ARGUMENTS
 
 DEFAULT_MCMC_PARSER_ARGUMENTS = DEFAULT_PARSER_ARGUMENTS + [
@@ -599,6 +610,8 @@ DEFAULT_MCMC_PARSER_ARGUMENTS = DEFAULT_PARSER_ARGUMENTS + [
 
 CALL_MCMC_PARSER_ARGUMENTS = [
     haplotypes,
+    haplotype_frequencies,
+    skip_rare_haplotypes,
 ] + DEFAULT_MCMC_PARSER_ARGUMENTS
 
 ASSEMBLE_MCMC_PARSER_ARGUMENTS = (
@@ -822,6 +835,8 @@ def collect_call_exact_program_arguments(arguments):
     data = collect_default_program_arguments(arguments)
     data["vcf"] = arguments.haplotypes[0]
     data["random_seed"] = None
+    data["haplotype_frequencies_tag"] = arguments.haplotype_frequencies[0]
+    data["skip_rare_haplotypes"] = arguments.skip_rare_haplotypes[0]
     return data
 
 
@@ -842,6 +857,8 @@ def collect_default_mcmc_program_arguments(arguments):
 def collect_call_mcmc_program_arguments(arguments):
     data = collect_default_mcmc_program_arguments(arguments)
     data["vcf"] = arguments.haplotypes[0]
+    data["haplotype_frequencies_tag"] = arguments.haplotype_frequencies[0]
+    data["skip_rare_haplotypes"] = arguments.skip_rare_haplotypes[0]
     return data
 
 

--- a/mchap/application/baseclass.py
+++ b/mchap/application/baseclass.py
@@ -51,6 +51,8 @@ class program(object):
     skip_duplicates: bool = True
     skip_qcfail: bool = True
     skip_supplementary: bool = True
+    haplotype_frequencies_tag: str = None
+    skip_rare_haplotypes: float = None
     report_fields: list = ()
     n_cores: int = 1
     precision: int = 3
@@ -97,7 +99,11 @@ class program(object):
     def loci(self):
         with pysam.VariantFile(self.vcf) as f:
             for record in f.fetch():
-                locus = Locus.from_variant_record(record)
+                locus = Locus.from_variant_record(
+                    record,
+                    frequency_tag=self.haplotype_frequencies_tag,
+                    frequency_min=self.skip_rare_haplotypes,
+                )
                 yield locus
 
     def header_contigs(self):

--- a/mchap/application/baseclass.py
+++ b/mchap/application/baseclass.py
@@ -51,8 +51,6 @@ class program(object):
     skip_duplicates: bool = True
     skip_qcfail: bool = True
     skip_supplementary: bool = True
-    haplotype_frequencies_tag: str = None
-    skip_rare_haplotypes: float = None
     report_fields: list = ()
     n_cores: int = 1
     precision: int = 3
@@ -97,14 +95,7 @@ class program(object):
         return formatfields
 
     def loci(self):
-        with pysam.VariantFile(self.vcf) as f:
-            for record in f.fetch():
-                locus = Locus.from_variant_record(
-                    record,
-                    frequency_tag=self.haplotype_frequencies_tag,
-                    frequency_min=self.skip_rare_haplotypes,
-                )
-                yield locus
+        raise NotImplementedError()
 
     def header_contigs(self):
         with pysam.VariantFile(self.vcf) as f:

--- a/mchap/application/baseclass.py
+++ b/mchap/application/baseclass.py
@@ -93,7 +93,7 @@ class program(object):
             "GPM",
             "PHPM",
             "MCI",
-        ] + [f for f in ["GP", "GL", "AFP", "DS"] if f in self.report_fields]
+        ] + [f for f in ["AFP", "DS", "GP", "GL"] if f in self.report_fields]
         return formatfields
 
     def loci(self):

--- a/mchap/application/call_baseclass.py
+++ b/mchap/application/call_baseclass.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import pysam
+
+from mchap.application import baseclass
+from mchap.io import Locus
+
+
+@dataclass
+class program(baseclass.program):
+    haplotype_frequencies_tag: str = None
+    use_haplotype_frequencies_prior: bool = False
+    skip_rare_haplotypes: float = None
+
+    def loci(self):
+        with pysam.VariantFile(self.vcf) as f:
+            for record in f.fetch():
+                locus = Locus.from_variant_record(
+                    record,
+                    frequency_tag=self.haplotype_frequencies_tag,
+                    frequency_min=self.skip_rare_haplotypes,
+                )
+                yield locus

--- a/mchap/application/call_exact.py
+++ b/mchap/application/call_exact.py
@@ -15,8 +15,12 @@ from mchap.calling.exact import (
     genotype_posteriors,
     alternate_dosage_posteriors,
     posterior_allele_frequencies,
+    genotypes_with_allele,
 )
-from mchap.jitutils import natural_log_to_log10, index_as_genotype_alleles
+from mchap.jitutils import (
+    natural_log_to_log10,
+    index_as_genotype_alleles,
+)
 
 from mchap.io import qual_of_prob
 
@@ -70,6 +74,21 @@ class program(baseclass.program):
         ]:
             data.sampledata[field] = dict()
         haplotypes = data.locus.encode_haplotypes()
+
+        # need to skip reference allele if it was bellow specified frequency
+        # TODO: this logic can be handled by setting ref allele
+        # freq to 0 when using prior allele freqs.
+        if self.haplotype_frequencies_tag and self.skip_rare_haplotypes:
+            exclude_reference_allele = (
+                data.locus.frequencies[0] < self.skip_rare_haplotypes
+            )
+        else:
+            exclude_reference_allele = False
+        if exclude_reference_allele:
+            evaluated_haplotypes = haplotypes[1:]
+        else:
+            evaluated_haplotypes = haplotypes
+
         for sample in data.samples:
             # wrap in try clause to pass sample info back with any exception
             try:
@@ -80,6 +99,7 @@ class program(baseclass.program):
 
                 # call haplotypes
                 if ("GL" in data.formatfields) or ("GP" in data.formatfields):
+
                     # calculate full arrays
                     llks = genotype_likelihoods(
                         reads=reads,
@@ -87,12 +107,25 @@ class program(baseclass.program):
                         haplotypes=haplotypes,
                         ploidy=ploidy,
                     )
-                    probabilities = genotype_posteriors(
-                        log_likelihoods=llks,
-                        ploidy=ploidy,
-                        n_alleles=len(haplotypes),
-                        inbreeding=inbreeding,
-                    )
+                    if exclude_reference_allele:
+                        # TODO: this logic can be handled by setting ref allele
+                        # freq to 0 when using prior allele freqs.
+                        idx = ~genotypes_with_allele(ploidy, len(haplotypes), allele=0)
+                        probabilities_evaluated = genotype_posteriors(
+                            log_likelihoods=llks[idx],
+                            ploidy=ploidy,
+                            n_alleles=len(haplotypes) - 1,
+                            inbreeding=inbreeding,
+                        )
+                        probabilities = np.zeros(len(llks))
+                        probabilities[idx] = probabilities_evaluated
+                    else:
+                        probabilities = genotype_posteriors(
+                            log_likelihoods=llks,
+                            ploidy=ploidy,
+                            n_alleles=len(haplotypes),
+                            inbreeding=inbreeding,
+                        )
                     idx = np.argmax(probabilities)
                     alleles = index_as_genotype_alleles(idx, ploidy)
                     genotype_prob = probabilities[idx]
@@ -121,17 +154,26 @@ class program(baseclass.program):
                     mode_results = posterior_mode(
                         reads=reads,
                         read_counts=read_counts,
-                        haplotypes=haplotypes,
+                        haplotypes=evaluated_haplotypes,
                         ploidy=ploidy,
                         inbreeding=inbreeding,
                         return_phenotype_prob=True,
                         return_posterior_frequencies="AFP" in data.formatfields,
                     )
                     alleles, _, genotype_prob, phenotype_prob = mode_results[0:4]
+                    if exclude_reference_allele:
+                        # TODO: this logic can be handled by setting ref allele
+                        # freq to 0 when using prior allele freqs.
+                        alleles += 1
                     if "AFP" in data.formatfields:
-                        data.sampledata["AFP"][sample] = np.round(
-                            mode_results[-1], self.precision
-                        )
+                        freqs = np.round(mode_results[-1], self.precision)
+                        if exclude_reference_allele:
+                            # TODO: this logic can be handled by setting ref allele
+                            # freq to 0 when using prior allele freqs.
+                            freqs_evaluated = freqs
+                            freqs = np.zeros(len(freqs) + 1)
+                            freqs[1:] = freqs_evaluated
+                        data.sampledata["AFP"][sample] = freqs
 
                 # store variables
                 data.sampledata["alleles"][sample] = alleles

--- a/mchap/calling/classes.py
+++ b/mchap/calling/classes.py
@@ -141,6 +141,25 @@ class GenotypeAllelesMultiTrace(object):
     genotypes: np.ndarray
     llks: np.ndarray
 
+    def relabel(self, labels):
+        """Returns a new GenotypeTrace object with relabeled alleles.
+
+        Parameters
+        ----------
+        labels : ndarray, int, shape (n_alleles,)
+            New integer labels.
+
+        Returns
+        -------
+        trace : GenotypeTrace
+            A new instance of the GenotypeTrace with relabeled alleles.
+        """
+        new = type(self)(
+            labels[self.genotypes],
+            self.llks,
+        )
+        return new
+
     def burn(self, n):
         """Returns a new GenotypeTrace object without the first
         `n` observations of each chain.

--- a/mchap/calling/classes.py
+++ b/mchap/calling/classes.py
@@ -15,6 +15,7 @@ class CallingMCMC(Assembler):
 
     ploidy: int
     haplotypes: np.ndarray
+    frequencies: np.array = None
     inbreeding: float = 0
     steps: int = 1000
     chains: int = 2
@@ -30,6 +31,8 @@ class CallingMCMC(Assembler):
     haplotypes : ndarray, int, shape, (n_haplotypes, n_pos)
         Number of possible alleles at each position in the
         assembled locus.
+    frequencies : ndarray, float , shape (n_haplotypes, )
+        Optional prior frequencies for each haplotype allele.
     inbreeding : float
         Expected inbreeding coefficient of genotype.
     steps : int, optional
@@ -113,6 +116,7 @@ class CallingMCMC(Assembler):
                 reads=reads,
                 read_counts=read_counts,
                 inbreeding=self.inbreeding,
+                frequencies=self.frequencies,
                 n_steps=self.steps,
                 cache=True,
                 step_type=step_type,

--- a/mchap/calling/exact.py
+++ b/mchap/calling/exact.py
@@ -12,6 +12,7 @@ from mchap.jitutils import (
     genotype_alleles_as_index,
     index_as_genotype_alleles,
     add_log_prob,
+    comb_with_replacement,
 )
 
 
@@ -356,3 +357,31 @@ def alternate_dosage_posteriors(genotype_alleles, probabilities):
         probs[i] = probabilities[idx]
     idx = np.argsort(indices)
     return genotypes[idx], probs[idx]
+
+
+@njit(cache=True)
+def genotypes_with_allele(ploidy, n_alleles, allele=0):
+    """Identify genotypes containing a specific allele.
+
+    Parameters
+    ----------
+    ploidy : int
+        Ploidy of organism.
+    n_alleles : int
+        Total number of possible (haplotype) alleles at this locus.
+    allele : int
+        Allele to check for.
+
+    Returns
+    -------
+    mask : ndarray, bool, shape(n_genotypes, )
+        Array indicating genotypes containing allele.
+    """
+    n_genotypes = comb_with_replacement(n_alleles, ploidy)
+    out = np.zeros(n_genotypes, dtype=np.bool8)
+    genotype = np.zeros(ploidy, dtype=np.int64)
+    for i in range(n_genotypes):
+        if allele in genotype:
+            out[i] = True
+        increment_genotype(genotype)
+    return out

--- a/mchap/calling/prior.py
+++ b/mchap/calling/prior.py
@@ -2,11 +2,11 @@ import numpy as np
 import numba
 from math import lgamma
 
-from mchap.calling.utils import allelic_dosage, count_allele
+from mchap.calling.utils import count_allele
 
 
 @numba.njit(cache=True)
-def inbreeding_as_dispersion(inbreeding, unique_haplotypes):
+def calculate_alphas(inbreeding, frequencies):
     """Calculate dispersion parameter of a Dirichlet-multinomial
     distribution assuming equal population frequency of each haplotype.
 
@@ -14,20 +14,20 @@ def inbreeding_as_dispersion(inbreeding, unique_haplotypes):
     ----------
     inbreeding : float
         Expected inbreeding coefficient of the sample.
-    unique_haplotypes : int
-        Number of possible haplotype alleles at this locus.
+    frequencies : ndarray, float, shape (n_alleles)
+        Prior allele frequencies.
 
     Returns
     -------
-    dispersion : float
-        Dispersion parameter for all haplotypes.
+    alphas : ndarray, float, shape (n_alleles)
+        Dispersion parameters for each allele.
     """
-    return (1 / unique_haplotypes) * ((1 - inbreeding) / inbreeding)
+    return frequencies * ((1 - inbreeding) / inbreeding)
 
 
 @numba.njit(cache=True)
 def log_genotype_allele_prior(
-    genotype, variable_allele, unique_haplotypes, inbreeding=0
+    genotype, variable_allele, unique_haplotypes, inbreeding=0, frequencies=None
 ):
     """Log probability that a genotype contains a specified allele
     given its other alleles are treated as constants.
@@ -56,19 +56,27 @@ def log_genotype_allele_prior(
 
     # if not inbred use null prior of a randomly chosen allele
     if inbreeding == 0:
-        return np.log(1 / unique_haplotypes)
+        if frequencies is None:
+            return np.log(1 / unique_haplotypes)
+        else:
+            return np.log(frequencies[genotype[variable_allele]])
 
-    # base alpha for flat prior
-    alpha = inbreeding_as_dispersion(inbreeding, unique_haplotypes)
+    # count of alleles held as constant
+    constant_sum = len(genotype) - 1
+
+    # count of alleles held as constant that are IBS with variable allele
+    constant_ibs = count_allele(genotype, genotype[variable_allele]) - 1
 
     # sum of alpha parameters accounting for constant alleles
-    constant = np.delete(genotype, variable_allele)
-    counts = allelic_dosage(constant)
-    sum_alpha = np.sum(counts) + alpha * unique_haplotypes
-
-    # alpha parameter for variable allele
-    count = count_allele(genotype, genotype[variable_allele]) - 1
-    variable_alpha = alpha + count
+    if frequencies is None:
+        # base alpha for flat prior
+        alpha = calculate_alphas(inbreeding, 1 / unique_haplotypes)
+        sum_alpha = constant_sum + alpha * unique_haplotypes
+        variable_alpha = alpha + constant_ibs
+    else:
+        alphas = calculate_alphas(inbreeding, frequencies)
+        sum_alpha = constant_sum + alphas.sum()
+        variable_alpha = alphas[genotype[variable_allele]] + constant_ibs
 
     # dirichlet-multinomial PMF
     left = lgamma(sum_alpha) - lgamma(1 + sum_alpha)

--- a/mchap/calling/prior.py
+++ b/mchap/calling/prior.py
@@ -140,13 +140,13 @@ def log_genotype_prior(genotype, unique_haplotypes, inbreeding=0, frequencies=No
 
     # right side of equation
     prod = 0.0  # log(1.0)
-    for i in range(len(dosage)):
+    for i in range(ploidy):
         dose = dosage[i]
         if dose > 0:
             if frequencies is None:
                 alpha_i = alpha_const
             else:
-                alpha_i = alphas[i]
+                alpha_i = alphas[genotype[i]]
             num = lgamma(dose + alpha_i)
             denom = lgamma(dose + 1) + lgamma(alpha_i)
             prod += num - denom

--- a/mchap/jitutils.py
+++ b/mchap/jitutils.py
@@ -18,6 +18,8 @@ def add_log_prob(x, y):
         The log-transformed sum of the un-transformed `x` and `y`.
 
     """
+    if x == y == -np.inf:
+        return -np.inf
     if x > y:
         return x + np.log1p(np.exp(y - x))
     else:

--- a/mchap/tests/test_application_call.py
+++ b/mchap/tests/test_application_call.py
@@ -8,14 +8,16 @@ from mchap.application.call import program
 
 
 @pytest.mark.parametrize(
-    "bams,cli_extra,output_vcf",
+    "input_vcf,bams,cli_extra,output_vcf",
     [
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [],
             "simple.output.mixed_depth.call.vcf",
         ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -23,7 +25,21 @@ from mchap.application.call import program
             ],
             "simple.output.mixed_depth.call.frequencies.vcf",
         ),
+        (  # test using mock input will low ref allele frequency at first allele
+            "mock.input.frequencies.skiprare.vcf",
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            [
+                "--haplotype-frequencies",
+                "AFP",
+                "--skip-rare-haplotypes",
+                "0.1",
+                "--report",
+                "AFP",
+            ],
+            "simple.output.mixed_depth.call.frequencies.skiprare.vcf",
+        ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -35,6 +51,7 @@ from mchap.application.call import program
             "simple.output.mixed_depth.call.likelihoods.vcf",
         ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -48,11 +65,11 @@ from mchap.application.call import program
     ],
 )
 @pytest.mark.parametrize("n_cores", [1, 2])
-def test_Program__run_stdout(bams, cli_extra, output_vcf, n_cores):
+def test_Program__run_stdout(input_vcf, bams, cli_extra, output_vcf, n_cores):
     path = pathlib.Path(__file__).parent.absolute()
     path = path / "test_io/data"
 
-    VCF = str(path / "simple.output.mixed_depth.assemble.vcf")
+    VCF = str(path / input_vcf)
     BAMS = [str(path / bam) for bam in bams]
 
     command = (

--- a/mchap/tests/test_application_call_exact.py
+++ b/mchap/tests/test_application_call_exact.py
@@ -8,14 +8,16 @@ from mchap.application.call_exact import program
 
 
 @pytest.mark.parametrize(
-    "bams,cli_extra,output_vcf",
+    "input_vcf,bams,cli_extra,output_vcf",
     [
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [],
             "simple.output.mixed_depth.call-exact.vcf",
         ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -23,7 +25,35 @@ from mchap.application.call_exact import program
             ],
             "simple.output.mixed_depth.call-exact.frequencies.vcf",
         ),
+        (  # test using mock input will low ref allele frequency at first allele
+            "mock.input.frequencies.skiprare.vcf",
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            [
+                "--haplotype-frequencies",
+                "AFP",
+                "--skip-rare-haplotypes",
+                "0.1",
+                "--report",
+                "AFP",
+            ],
+            "simple.output.mixed_depth.call-exact.frequencies.skiprare.vcf",
+        ),
+        (  # test using mock input will low ref allele frequency at first allele
+            "mock.input.frequencies.skiprare.vcf",
+            ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
+            [
+                "--haplotype-frequencies",
+                "AFP",
+                "--skip-rare-haplotypes",
+                "0.1",
+                "--report",
+                "AFP",
+                "GP",
+            ],
+            "simple.output.mixed_depth.call-exact.frequencies.posteriors.skiprare.vcf",
+        ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -35,6 +65,7 @@ from mchap.application.call_exact import program
             "simple.output.mixed_depth.call-exact.likelihoods.vcf",
         ),
         (
+            "simple.output.mixed_depth.assemble.vcf",
             ["simple.sample1.bam", "simple.sample2.deep.bam", "simple.sample3.bam"],
             [
                 "--report",
@@ -48,11 +79,11 @@ from mchap.application.call_exact import program
     ],
 )
 @pytest.mark.parametrize("n_cores", [1, 2])
-def test_Program__run_stdout(bams, cli_extra, output_vcf, n_cores):
+def test_Program__run_stdout(input_vcf, bams, cli_extra, output_vcf, n_cores):
     path = pathlib.Path(__file__).parent.absolute()
     path = path / "test_io/data"
 
-    VCF = str(path / "simple.output.mixed_depth.assemble.vcf")
+    VCF = str(path / input_vcf)
     BAMS = [str(path / bam) for bam in bams]
 
     command = (

--- a/mchap/tests/test_calling/test_calling_prior.py
+++ b/mchap/tests/test_calling/test_calling_prior.py
@@ -2,9 +2,31 @@ import numpy as np
 import pytest
 
 from mchap.calling.prior import (
-    inbreeding_as_dispersion,
+    calculate_alphas,
     log_genotype_allele_prior,
 )
+
+
+@pytest.mark.parametrize(
+    "inbreeding,frequencies,alphas",
+    [
+        [0.1, np.array([0.25, 0.25, 0.25, 0.25]), np.array([2.25, 2.25, 2.25, 2.25])],
+        [
+            0.1,
+            np.array([0.0, 0.25, 0.25, 0.25, 0.25]),
+            np.array([0.0, 2.25, 2.25, 2.25, 2.25]),
+        ],
+        [0.5, np.array([0.25, 0.25, 0.25, 0.25]), np.array([0.25, 0.25, 0.25, 0.25])],
+        [
+            0.5,
+            np.array([0.0, 0.25, 0.25, 0.25, 0.25]),
+            np.array([0.0, 0.25, 0.25, 0.25, 0.25]),
+        ],
+    ],
+)
+def test_calculate_alphas(inbreeding, frequencies, alphas):
+    actual = calculate_alphas(inbreeding, frequencies)
+    np.testing.assert_array_almost_equal(actual, alphas)
 
 
 @pytest.mark.parametrize(
@@ -19,8 +41,8 @@ from mchap.calling.prior import (
         [0.1, 32, 0.28125],
     ],
 )
-def test_inbreeding_as_dispersion(inbreeding, unique_haplotypes, dispersion):
-    actual = inbreeding_as_dispersion(inbreeding, unique_haplotypes)
+def test_calculate_alphas__flat_frequency(inbreeding, unique_haplotypes, dispersion):
+    actual = calculate_alphas(inbreeding, 1 / unique_haplotypes)
     assert actual == dispersion
 
 

--- a/mchap/tests/test_calling/test_calling_prior.py
+++ b/mchap/tests/test_calling/test_calling_prior.py
@@ -47,6 +47,7 @@ def test_calculate_alphas__flat_frequency(inbreeding, unique_haplotypes, dispers
     assert actual == dispersion
 
 
+@pytest.mark.parametrize("use_frequencies", [False, True])
 @pytest.mark.parametrize(
     "genotype,variable_allele,unique_haplotypes,inbreeding,expect",
     [
@@ -66,15 +67,24 @@ def test_calculate_alphas__flat_frequency(inbreeding, unique_haplotypes, dispers
     ],
 )
 def test_log_genotype_allele_prior__flat_frequency(
-    genotype, variable_allele, unique_haplotypes, inbreeding, expect
+    genotype, variable_allele, unique_haplotypes, inbreeding, use_frequencies, expect
 ):
     genotype = np.array(genotype)
+    if use_frequencies:
+        frequencies = np.ones(unique_haplotypes) / unique_haplotypes
+    else:
+        frequencies = None
     actual = log_genotype_allele_prior(
-        genotype, variable_allele, unique_haplotypes, inbreeding
+        genotype,
+        variable_allele,
+        unique_haplotypes,
+        inbreeding,
+        frequencies=frequencies,
     )
     np.testing.assert_almost_equal(actual, expect)
 
 
+@pytest.mark.parametrize("use_frequencies", [False, True])
 @pytest.mark.parametrize(
     "genotype,unique_haplotypes,inbreeding,probability",
     [
@@ -96,11 +106,17 @@ def test_log_genotype_allele_prior__flat_frequency(
     ],
 )
 def test_log_genotype_prior__flat_frequency(
-    genotype, unique_haplotypes, inbreeding, probability
+    genotype, unique_haplotypes, inbreeding, use_frequencies, probability
 ):
     # Actual probabilities for inbreeding == 0 calculated independently using scipy multinomial
     # Actual probabilities for inbreeding > 0 calculated independently using tensorflow-probabilities
     expect = np.log(probability)
     genotype = np.array(genotype)
-    actual = log_genotype_prior(genotype, unique_haplotypes, inbreeding)
+    if use_frequencies:
+        frequencies = np.ones(unique_haplotypes) / unique_haplotypes
+    else:
+        frequencies = None
+    actual = log_genotype_prior(
+        genotype, unique_haplotypes, inbreeding, frequencies=frequencies
+    )
     np.testing.assert_almost_equal(actual, expect, decimal=10)

--- a/mchap/tests/test_io/data/mock.input.frequencies.skiprare.vcf
+++ b/mchap/tests/test_io/data/mock.input.frequencies.skiprare.vcf
@@ -1,0 +1,36 @@
+##fileformat=VCFv4.3
+##fileDate=20220406
+##source=mchap v0.5.1
+##phasing=None
+##commandline="mockup"
+##randomseed=11
+##contig=<ID=CHR1,length=60>
+##contig=<ID=CHR2,length=60>
+##contig=<ID=CHR3,length=60>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples with data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=RCOUNT,Number=1,Type=Integer,Description="Total number of observed reads across all samples">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
+##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
+##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=RCOUNT,Number=1,Type=Integer,Description="Total count of read pairs within haplotype interval">
+##FORMAT=<ID=RCALLS,Number=1,Type=Integer,Description="Total count of read base calls matching a known variant">
+##FORMAT=<ID=MEC,Number=1,Type=Integer,Description="Minimum error correction">
+##FORMAT=<ID=MECP,Number=1,Type=Float,Description="Minimum error correction proportion">
+##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
+##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
+##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=3;AC=3,2;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0.09,0.5,0.41
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA,AAAATAAAAGAAAAAAAAAA	.	.	AN=4;AC=3,2,1;NS=3;DP=168;RCOUNT=288;END=30;NVAR=2;SNVPOS=5,10;AFP=0.481,0.235,0.178,0.093
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.posteriors.skiprare.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.posteriors.skiprare.vcf
@@ -1,0 +1,37 @@
+##fileformat=VCFv4.3
+##fileDate=20220406
+##source=mchap v0.5.1
+##phasing=None
+##commandline="mchap call-exact --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --haplotypes mock.input.frequencies.skiprare.vcf --haplotype-frequencies AFP --skip-rare-haplotypes 0.1 --report AFP GP"
+##randomseed=None
+##contig=<ID=CHR1,length=60>
+##contig=<ID=CHR2,length=60>
+##contig=<ID=CHR3,length=60>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples with data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=RCOUNT,Number=1,Type=Integer,Description="Total number of observed reads across all samples">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
+##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
+##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=RCOUNT,Number=1,Type=Integer,Description="Total count of read pairs within haplotype interval">
+##FORMAT=<ID=RCALLS,Number=1,Type=Integer,Description="Total count of read base calls matching a known variant">
+##FORMAT=<ID=MEC,Number=1,Type=Integer,Description="Minimum error correction">
+##FORMAT=<ID=MECP,Number=1,Type=Float,Description="Minimum error correction proportion">
+##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
+##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
+##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+##FORMAT=<ID=GP,Number=G,Type=Float,Description="Genotype posterior probabilities">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=2;AC=8,4;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0,0.713,0.287	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP:GP	1/1/2/2:3:60:13:20:40:16:0.4:0.552:1:.:0,0.609,0.391:0,0,0,0,0,0,0,0,0.443,0,0,0.552,0,0.006,0	1/1/1/1:60:60:133:200:400:160:0.4:1:1:.:0,1,0:0,0,0,0,1,0,0,0,0,0,0,0,0,0,0	1/1/2/2:6:60:13:20:40:24:0.6:0.759:1:.:0,0.53,0.47:0,0,0,0,0,0,0,0,0.181,0,0,0.759,0,0.06,0
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP:GP	0/0/0/0:60:60:.:24:0:0:.:1:1:.:1:1	0/0/0/0:60:60:.:240:0:0:.:1:1:.:1:1	0/0/0/0:60:60:.:24:0:0:.:1:1:.:1:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA	.	.	AN=3;AC=4,2;NS=3;DP=192;RCOUNT=288;END=30;NVAR=1;SNVPOS=10;AFP=0.498,0.321,0.181	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP:GP	0/0/0/2:8:17:16:24:16:0:0:0.827:0.981:.:0.707,0.005,0.288:0,0,0,0,0,0.827,0.019,0,0,0.153,0,0,0,0,0	0/0/1/2:60:60:160:240:160:0:0:1:1:.:0.5,0.25,0.25:0,0,0,0,0,0,1,0,0,0,0,0,0,0,0	0/1/1/1:8:17:16:24:16:0:0:0.827:0.981:.:0.288,0.707,0.005:0,0,0.153,0.827,0,0,0,0.019,0,0,0,0,0,0,0
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP:GP	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1:1	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1:1	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.skiprare.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call-exact.frequencies.skiprare.vcf
@@ -1,0 +1,36 @@
+##fileformat=VCFv4.3
+##fileDate=20220406
+##source=mchap v0.5.1
+##phasing=None
+##commandline="mchap call-exact --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --haplotypes mock.input.frequencies.skiprare.vcf --haplotype-frequencies AFP --skip-rare-haplotypes 0.1 --report AFP"
+##randomseed=None
+##contig=<ID=CHR1,length=60>
+##contig=<ID=CHR2,length=60>
+##contig=<ID=CHR3,length=60>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples with data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=RCOUNT,Number=1,Type=Integer,Description="Total number of observed reads across all samples">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
+##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
+##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=RCOUNT,Number=1,Type=Integer,Description="Total count of read pairs within haplotype interval">
+##FORMAT=<ID=RCALLS,Number=1,Type=Integer,Description="Total count of read base calls matching a known variant">
+##FORMAT=<ID=MEC,Number=1,Type=Integer,Description="Minimum error correction">
+##FORMAT=<ID=MECP,Number=1,Type=Float,Description="Minimum error correction proportion">
+##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
+##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
+##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=2;AC=8,4;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0,0.713,0.287	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	1/1/2/2:3:60:13:20:40:16:0.4:0.552:1:.:0,0.609,0.391	1/1/1/1:60:60:133:200:400:160:0.4:1:1:.:0,1,0	1/1/2/2:6:60:13:20:40:24:0.6:0.759:1:.:0,0.53,0.47
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.:1:1:.:1	0/0/0/0:60:60:.:240:0:0:.:1:1:.:1	0/0/0/0:60:60:.:24:0:0:.:1:1:.:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA	.	.	AN=3;AC=4,2;NS=3;DP=192;RCOUNT=288;END=30;NVAR=1;SNVPOS=10;AFP=0.498,0.321,0.181	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/2:8:17:16:24:16:0:0:0.827:0.981:.:0.707,0.005,0.288	0/0/1/2:60:60:160:240:160:0:0:1:1:.:0.5,0.25,0.25	0/1/1/1:8:17:16:24:16:0:0:0.827:0.981:.:0.288,0.707,0.005
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1	0/0/0/0:60:60:.:0:0:0:.:1:1:.:1

--- a/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.skiprare.vcf
+++ b/mchap/tests/test_io/data/simple.output.mixed_depth.call.frequencies.skiprare.vcf
@@ -1,0 +1,36 @@
+##fileformat=VCFv4.3
+##fileDate=20220406
+##source=mchap v0.5.1
+##phasing=None
+##commandline="mchap call --bam simple.sample1.bam simple.sample2.deep.bam simple.sample3.bam --ploidy 4 --haplotypes mock.input.frequencies.skiprare.vcf --haplotype-frequencies AFP --skip-rare-haplotypes 0.1 --mcmc-steps 500 --mcmc-burn 100 --mcmc-seed 11 --report AFP"
+##randomseed=11
+##contig=<ID=CHR1,length=60>
+##contig=<ID=CHR2,length=60>
+##contig=<ID=CHR3,length=60>
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of samples with data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Combined depth across samples">
+##INFO=<ID=RCOUNT,Number=1,Type=Integer,Description="Total number of observed reads across all samples">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position on CHROM">
+##INFO=<ID=NVAR,Number=1,Type=Integer,Description="Number of input variants within assembly locus">
+##INFO=<ID=SNVPOS,Number=.,Type=Integer,Description="Relative (1-based) positions of SNVs within haplotypes">
+##INFO=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">
+##FORMAT=<ID=PHQ,Number=1,Type=Integer,Description="Phenotype quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth">
+##FORMAT=<ID=RCOUNT,Number=1,Type=Integer,Description="Total count of read pairs within haplotype interval">
+##FORMAT=<ID=RCALLS,Number=1,Type=Integer,Description="Total count of read base calls matching a known variant">
+##FORMAT=<ID=MEC,Number=1,Type=Integer,Description="Minimum error correction">
+##FORMAT=<ID=MECP,Number=1,Type=Float,Description="Minimum error correction proportion">
+##FORMAT=<ID=GPM,Number=1,Type=Float,Description="Genotype posterior mode probability">
+##FORMAT=<ID=PHPM,Number=1,Type=Float,Description="Phenotype posterior mode probability">
+##FORMAT=<ID=MCI,Number=1,Type=Integer,Description="Replicate Markov-chain incongruence, 0 = none, 1 = incongruence, 2 = putative CNV">
+##FORMAT=<ID=AFP,Number=R,Type=Float,Description="Posterior mean allele frequencies">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1	SAMPLE2	SAMPLE3
+CHR1	6	CHR1_05_25	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAAGAAAAAATAA,ACAAAAAAAAGAAAAAACAA	.	.	AN=2;AC=8,4;NS=3;DP=159;RCOUNT=240;END=25;NVAR=3;SNVPOS=2,11,18;AFP=0,0.715,0.285	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	1/1/2/2:4:60:13:20:40:16:0.4:0.554:1:0:0,0.61,0.39	1/1/1/1:60:60:133:200:400:160:0.4:1:1:0:0,1,0	1/1/2/2:6:60:13:20:40:24:0.6:0.764:1:0:0,0.535,0.465
+CHR1	31	CHR1_30_50	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=288;END=50;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:24:0:0:.:1:1:0:1	0/0/0/0:60:60:.:240:0:0:.:1:1:0:1	0/0/0/0:60:60:.:24:0:0:.:1:1:0:1
+CHR2	11	CHR2_10_30	AAAAAAAAAAAAAAAAAAAA	AAAAAAAAAGAAAAAAAAAA,AAAAAAAAATAAAAAAAAAA	.	.	AN=3;AC=4,2;NS=3;DP=192;RCOUNT=288;END=30;NVAR=1;SNVPOS=10;AFP=0.498,0.321,0.181	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/2:8:16:16:24:16:0:0:0.825:0.974:0:0.706,0.007,0.288	0/0/1/2:60:60:160:240:160:0:0:1:1:0:0.5,0.25,0.25	0/1/1/1:8:16:16:24:16:0:0:0.824:0.978:0:0.288,0.706,0.006
+CHR3	21	CHR3_20_40	AAAAAAAAAAAAAAAAAAAA	.	.	.	AN=1;AC=.;NS=3;DP=.;RCOUNT=0;END=40;NVAR=0;SNVPOS=.;AFP=1	GT:GQ:PHQ:DP:RCOUNT:RCALLS:MEC:MECP:GPM:PHPM:MCI:AFP	0/0/0/0:60:60:.:0:0:0:.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.:1:1:0:1	0/0/0/0:60:60:.:0:0:0:.:1:1:0:1


### PR DESCRIPTION
- Option to specify population prior allele frequencies in mchap call and call-exact #120 
- Option to ignore haplotypes based upon population prior allele frequencies in mchap call and call-exact #113 